### PR TITLE
Remove broker's truststore location and password property

### DIFF
--- a/manifests/kafkaui-values.yaml
+++ b/manifests/kafkaui-values.yaml
@@ -9,8 +9,6 @@ yamlApplicationConfig:
           sasl.jaas.config: org.apache.kafka.common.security.plain.PlainLoginModule required username="kafka" password="kafka-secret";
           ssl.keystore.location: /mnt/sslcerts/keystore.p12
           ssl.keystore.password: mystorepassword
-          ssl.truststore.location: /mnt/sslcerts/truststore.p12
-          ssl.truststore.password: mystorepassword
         kafkaConnect:
           - name: connect-cluster
             address: https://connect.confluent.svc.cluster.local:8083


### PR DESCRIPTION
Quoting Kafka-UI release notes for version 0.6.0:

```
BREAKING CHANGES

If you've been using SSL for any component (Clusters, SR, KSQL, KC, etc.), you have to migrate your properties a bit;
Now we supply just one truststore per cluster, keystore stays the same way, one per component:

      KAFKA_CLUSTERS_0_SSL_TRUSTSTORELOCATION: /kafka.truststore.jks
      KAFKA_CLUSTERS_0_SSL_TRUSTSTOREPASSWORD: "secret"

All other truststore-related properties have been deprecated.
```