### PR TITLE
Fix CSV source connector key

### DIFF
--- a/usecases/csv/connectors/csv-source-connector.json
+++ b/usecases/csv/connectors/csv-source-connector.json
@@ -23,9 +23,9 @@
   "csv.null.field.indicator": "EMPTY_SEPARATORS",
   "schema.generation.enabled": "true",
   "schema.generation.key.fields": "email",
-  "transforms":"createKey,extractString",
-  "transforms.createKey.type":"org.apache.kafka.connect.transforms.ValueToKey",
-  "transforms.createKey.fields":"email",
-  "transforms.extractString.type":"org.apache.kafka.connect.transforms.ExtractField$Key",
-  "transforms.extractString.field":"email"
+  "transforms": "createKey,extractString",
+  "transforms.createKey.type": "org.apache.kafka.connect.transforms.ValueToKey",
+  "transforms.createKey.fields": "email",
+  "transforms.extractString.type": "org.apache.kafka.connect.transforms.ExtractField$Key",
+  "transforms.extractString.field": "email"
 }

--- a/usecases/csv/connectors/csv-source-connector.json
+++ b/usecases/csv/connectors/csv-source-connector.json
@@ -2,6 +2,7 @@
   "name": "csv-source-connector",
   "connector.class": "com.github.jcustenborder.kafka.connect.spooldir.SpoolDirCsvSourceConnector",
   "tasks.max": "1",
+  "key.converter": "org.apache.kafka.connect.storage.StringConverter",
   "value.converter": "io.confluent.connect.avro.AvroConverter",
   "value.converter.schema.registry.url": "https://schemaregistry.confluent.svc.cluster.local:8081",
   "value.converter.schema.registry.basic.auth.credentials.source": "USER_INFO",
@@ -21,5 +22,10 @@
   "csv.first.row.as.header": "true",
   "csv.null.field.indicator": "EMPTY_SEPARATORS",
   "schema.generation.enabled": "true",
-  "schema.generation.key.fields": "email"
+  "schema.generation.key.fields": "email",
+  "transforms":"createKey,extractString",
+  "transforms.createKey.type":"org.apache.kafka.connect.transforms.ValueToKey",
+  "transforms.createKey.fields":"email",
+  "transforms.extractString.type":"org.apache.kafka.connect.transforms.ExtractField$Key",
+  "transforms.extractString.field":"email"
 }


### PR DESCRIPTION
The `email` field in the key was initially created in the following format: `{"email":"name@domain.com"}`. With this fix, the curly brackets, quotes, and the field name are removed, resulting in the email being represented as `name@domain.com`.