### PR TITLE
Fix phpLDAPadmin version

### DIFF
--- a/manifests/phpldapadmin-values.yaml
+++ b/manifests/phpldapadmin-values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: osixia/phpldapadmin-vf
-  tag: 7.7.7
+  tag: 0.9.0
 
 env:
   PHPLDAPADMIN_LDAP_HOSTS: "#PYTHON2BASH:[{'ldap://ldap.confluent.svc.cluster.local:389': [{'server': [{'tls': False}]},{'login': [{'bind_id': 'cn=admin,dc=test,dc=com'}]}]}, {'ldaps://ldap.confluent.svc.cluster.local:636': [{'server': [{'tls': True}]},{'login': [{'bind_id': 'cn=admin,dc=test,dc=com'}]}]}]"


### PR DESCRIPTION
In the preceding pull request, specifically PR #91, there was an inadvertent error in setting the image version to `7.7.7`.
This PR will revert it to its correct value: `0.9.0`.