### PR TITLE
Set the TLS LDAP server as non-TLS

### DIFF
--- a/manifests/phpldapadmin-values.yaml
+++ b/manifests/phpldapadmin-values.yaml
@@ -3,7 +3,7 @@ image:
   tag: 0.9.0
 
 env:
-  PHPLDAPADMIN_LDAP_HOSTS: "#PYTHON2BASH:[{'ldap://ldap.confluent.svc.cluster.local:389': [{'server': [{'tls': False}]},{'login': [{'bind_id': 'cn=admin,dc=test,dc=com'}]}]}, {'ldaps://ldap.confluent.svc.cluster.local:636': [{'server': [{'tls': True}]},{'login': [{'bind_id': 'cn=admin,dc=test,dc=com'}]}]}]"
+  PHPLDAPADMIN_LDAP_HOSTS: "#PYTHON2BASH:[{'ldap://ldap.confluent.svc.cluster.local:389': [{'server': [{'tls': False}]},{'login': [{'bind_id': 'cn=admin,dc=test,dc=com'}]}]}, {'ldaps://ldap.confluent.svc.cluster.local:636': [{'server': [{'tls': False}]},{'login': [{'bind_id': 'cn=admin,dc=test,dc=com'}]}]}]"
   PHPLDAPADMIN_HTTPS: "true"
   PHPLDAPADMIN_HTTPS_CRT_FILENAME: "phpldapadmin.pem"
   PHPLDAPADMIN_HTTPS_KEY_FILENAME: "phpldapadmin-key.pem"


### PR DESCRIPTION
Set the TLS LDAP server as non-TLS because phpLDAPadmin is using as default the STARTTLS method.

This is a patch. The correct way to fix this issue is to disable the STARTTLS method and not the TLS protocol.