### PR TITLE
Add environment variable to Schema Registry

### DIFF
--- a/docker-images/schema-registry/Dockerfile
+++ b/docker-images/schema-registry/Dockerfile
@@ -11,4 +11,7 @@ RUN yum -y install jq
 # Install curl
 RUN yum -y install curl
 
+# Add environment variable with keystore and truststore
+ENV SCHEMA_REGISTRY_OPTS="-Djavax.net.ssl.keyStore=/mnt/sslcerts/keystore.p12 -Djavax.net.ssl.trustStore=/mnt/sslcerts/truststore.p12 -Djavax.net.ssl.keyStorePassword=mystorepassword -Djavax.net.ssl.trustStorePassword=mystorepassword"
+
 USER appuser


### PR DESCRIPTION
Add environment variable `SCHEMA_REGISTRY_OPTS` with the information regarding the keystore and truststore to Schema Registry.